### PR TITLE
Fix vertical line

### DIFF
--- a/src/table.pl
+++ b/src/table.pl
@@ -120,9 +120,10 @@ sub printRecord {
         my $col = $cols->[$i];
         push(@colViews, stringViewPadding($col, $viewLength, $i == $col_count1));
     }
-    my $head = ($option_color && $header_flag) ? "\e[7m|" : "|";
-    my $tail = ($option_color && $header_flag) ? "|\e[0m" : "|";
-    print $head . join("|", @colViews) . $tail . "\n";
+    my $vert = encode_utf8("│");
+    my $head = ($option_color && $header_flag) ? "\e[7m$vert" : $vert;
+    my $tail = ($option_color && $header_flag) ? "$vert\e[0m" : $vert;
+    print $head . join($vert, @colViews) . $tail . "\n";
 }
 
 my $max_line_count = 1010;

--- a/src/table.pl
+++ b/src/table.pl
@@ -121,8 +121,8 @@ sub printRecord {
         push(@colViews, stringViewPadding($col, $viewLength, $i == $col_count1));
     }
     my $vert = encode_utf8("│");
-    my $head = ($option_color && $header_flag) ? "\e[7m$vert" : $vert;
-    my $tail = ($option_color && $header_flag) ? "$vert\e[0m" : $vert;
+    my $head = ($option_color && $header_flag) ? "\e[7m" : "";
+    my $tail = ($option_color && $header_flag) ? "\e[0m" : "";
     print $head . join($vert, @colViews) . $tail . "\n";
 }
 


### PR DESCRIPTION
- 罫線の表示に[罫線素片](https://ja.wikipedia.org/wiki/%E7%BD%AB%E7%B7%9A%E7%B4%A0%E7%89%87)を利用するようにしました。
- 行の先頭と末尾に罫線を表示しないようにしました。